### PR TITLE
DK Frost: rework priority rotation for 3.3.5a BiS Frost DPS

### DIFF
--- a/Classes/DeathKnight/Core.lua
+++ b/Classes/DeathKnight/Core.lua
@@ -61,6 +61,39 @@ local function diseasesUp(sim)
     return sim.ff_up and sim.bp_up
 end
 
+local function nextRuneReady(sim, runeType)
+    if not sim.rune_recovery or not sim.rune_recovery[runeType] then
+        return 999
+    end
+    local timers = sim.rune_recovery[runeType]
+    if timers[1] then
+        return timers[1]
+    end
+    return 999
+end
+
+-- Preserve a Blood/Death rune for Glyph of Disease refresh windows.
+-- If we spend the last Blood/Death rune too early, diseases can drop and force IT+PS.
+local function shouldReserveDiseaseRefreshRune(sim)
+    if not sim.has_glyph_disease or not diseasesUp(sim) then
+        return false
+    end
+
+    local availableBD = (sim.blood or 0) + (sim.death or 0)
+    if availableBD > 1 then
+        return false
+    end
+
+    local minDiseaseRemains = math.min(sim.ff_remains or 0, sim.bp_remains or 0)
+    if minDiseaseRemains > 8 then
+        return false
+    end
+
+    local timeUntilPestWindow = math.max(0, minDiseaseRemains - 3)
+    local nextBD = math.min(nextRuneReady(sim, "blood"), nextRuneReady(sim, "death"))
+    return nextBD > timeUntilPestWindow
+end
+
 -- ============================================================================
 -- RUNE RECOVERY TRACKING
 -- Reads actual rune cooldown timers to estimate when runes come back.
@@ -347,9 +380,15 @@ local frostConfig = {
     maxRecs = 3,
     allowDupes = true,
     cds = {
+        unbreakable_armor = "unbreakable_armor",
+        blood_tap = "blood_tap",
+        horn_of_winter = "horn_of_winter",
         empower_rune_weapon = "empower_rune_weapon",
     },
     baseCDs = {
+        unbreakable_armor = 60,
+        blood_tap = 60,
+        horn_of_winter = 20,
         empower_rune_weapon = 300,
     },
     auras = {
@@ -382,16 +421,25 @@ local frostConfig = {
         -- Talents
         sim.has_howling_blast = s.talent.howling_blast.rank > 0
         sim.has_frost_strike = s.talent.frost_strike.rank > 0
+        sim.has_unbreakable_armor = s.talent.unbreakable_armor.rank > 0
+        sim.unbreakable_armor_up = s.buff.unbreakable_armor.up
+        sim.horn_of_winter_up = s.buff.horn_of_winter.up
+        sim.strength_of_earth_totem_up = s.buff.strength_of_earth_totem.up
 
         -- Glyph of Frost Strike (32 RP instead of 40)
         sim.fs_cost = (s.glyph.frost_strike and s.glyph.frost_strike.enabled) and 32 or 40
         sim.has_glyph_disease = s.glyph.disease and s.glyph.disease.enabled
-        sim.in_unholy_presence = s.buff.unholy_presence.up
+        sim.in_blood_presence = s.buff.blood_presence.up
     end,
     getPriority = function(sim, recs)
-        -- Frost DPS wants Unholy Presence for haste
-        if not sim.in_unholy_presence then
-            return "unholy_presence"
+        -- Keep AP/STR raid buff up: Horn if neither Horn nor Strength of Earth is active
+        if not sim.horn_of_winter_up and not sim.strength_of_earth_totem_up then
+            return "horn_of_winter"
+        end
+
+        -- Frost DPS wants Blood Presence for damage
+        if not sim.in_blood_presence then
+            return "blood_presence"
         end
 
         -- Glyph of Disease: Pestilence refreshes both diseases (1 Blood rune)
@@ -412,6 +460,12 @@ local frostConfig = {
             return "plague_strike"
         end
 
+        -- Unbreakable Armor after presence and disease setup
+        if sim.has_unbreakable_armor and not sim.unbreakable_armor_up
+            and sim:ready("unbreakable_armor") and not DH:IsSnoozed("unbreakable_armor") then
+            return "unbreakable_armor"
+        end
+
         -- Rime proc: free Howling Blast (also applies FF)
         if sim.rime and sim.has_howling_blast then
             return "howling_blast"
@@ -427,34 +481,53 @@ local frostConfig = {
             return "obliterate"
         end
 
-        -- Blood Strike (Blood rune spender, converts to Death runes)
-        if canAfford(sim, 1, 0, 0) then
-            return "blood_strike"
-        end
-
-        -- Blood Tap: convert Blood rune to Death when F/U depleted
-        if sim.blood > 0 and sim.frost == 0 and sim.unholy == 0 and sim.death == 0
-            and not sim:ready("empower_rune_weapon") then
-            return "blood_tap"
-        end
-
         -- Frost Strike (RP dump)
         if sim.has_frost_strike and sim.rp >= sim.fs_cost then
             return "frost_strike"
         end
 
-        -- Empower Rune Weapon (no F/U/Death runes available)
-        if sim.frost == 0 and sim.unholy == 0 and sim.death == 0
+        -- Blood Tap: create a Death rune when exactly one Obliterate rune is missing.
+        -- This supports opener sequencing like IT -> PS -> UA -> BT -> OB.
+        if sim.blood > 0 and sim.death == 0
+            and ((sim.frost == 0 and sim.unholy > 0) or (sim.unholy == 0 and sim.frost > 0) or (sim.frost == 0 and sim.unholy == 0))
+            and diseasesUp(sim) and sim:ready("blood_tap") then
+            return "blood_tap"
+        end
+
+        -- Opener Pestilence sync: F+U spent after first OB, Blood rune still available,
+        -- ERW is ready (haven't used it yet). Dump the Blood rune on Pestilence to align
+        -- all rune timers before ERW resets everything. Requires Glyph of Disease.
+        if sim.has_glyph_disease and diseasesUp(sim)
+            and sim.frost == 0 and sim.unholy == 0
+            and sim.blood > 0
+            and sim:ready("empower_rune_weapon") and not DH:IsSnoozed("empower_rune_weapon") then
+            return "pestilence"
+        end
+
+        -- Empower Rune Weapon: fire before Blood Strike when F/U/Blood are all gone and we
+        -- cannot reach an Obliterate (e.g. post-Pestilence opener: F:0,U:0,B:0,D:1 left)
+        if sim.frost == 0 and sim.unholy == 0 and sim.blood == 0
+            and not canAfford(sim, 0, 1, 1)
             and sim:ready("empower_rune_weapon") and not DH:IsSnoozed("empower_rune_weapon") then
             return "empower_rune_weapon"
         end
 
-        -- Horn of Winter (free GCD, RP gen)
-        return "horn_of_winter"
+        -- Blood Strike (Blood rune spender, converts to Death runes)
+        -- Keep one Blood/Death rune banked if Glyph of Disease refresh is approaching.
+        if canAfford(sim, 1, 0, 0) and not shouldReserveDiseaseRefreshRune(sim) then
+            return "blood_strike"
+        end
+
+        -- Horn of Winter (free GCD, RP gen) only if off cooldown
+        if sim:ready("horn_of_winter") then
+            return "horn_of_winter"
+        end
+
+        return nil
     end,
     onCast = function(sim, key)
-        if key == "unholy_presence" then
-            sim.in_unholy_presence = true
+        if key == "blood_presence" then
+            sim.in_blood_presence = true
         elseif key == "icy_touch" then
             spendRunesTracked(sim, 0, 1, 0, 10)
             sim.ff_up = true
@@ -473,6 +546,8 @@ local frostConfig = {
             sim.rime = false
             sim.ff_up = true
             sim.ff_remains = 15
+        elseif key == "unbreakable_armor" then
+            sim.unbreakable_armor_up = true
         elseif key == "blood_strike" then
             spendRunesTracked(sim, 1, 0, 0, 10)
         elseif key == "frost_strike" then
@@ -496,6 +571,7 @@ local frostConfig = {
             end
         elseif key == "horn_of_winter" then
             sim.rp = math.min(sim.rp_max, sim.rp + 10)
+            sim.horn_of_winter_up = true
         end
     end,
     tickTime = function(sim, seconds)

--- a/Classes/DeathKnight/Core.lua
+++ b/Classes/DeathKnight/Core.lua
@@ -20,6 +20,7 @@ local state = DH.State
 -- spendRunes deducts from sim rune counts.
 -- ============================================================================
 
+---Returns true when rune and RP requirements can be paid with typed+death runes.
 local function canAfford(sim, bCost, fCost, uCost, rpCost)
     rpCost = rpCost or 0
     if sim.rp < rpCost then return false end
@@ -32,6 +33,7 @@ local function canAfford(sim, bCost, fCost, uCost, rpCost)
     return true
 end
 
+---Consumes requested runes, using death runes as overflow, then grants RP.
 local function spendRunes(sim, bCost, fCost, uCost, rpGain)
     -- Spend typed runes first, overflow to death
     local bSpend = math.min(bCost, sim.blood)
@@ -52,15 +54,18 @@ local function spendRunes(sim, bCost, fCost, uCost, rpGain)
     sim.rp = math.min(sim.rp_max, sim.rp + (rpGain or 10))
 end
 
+---Spends runic power without letting it drop below zero.
 local function spendRP(sim, cost)
     sim.rp = math.max(0, sim.rp - cost)
 end
 
 -- Both diseases up?
+---Returns true when Frost Fever and Blood Plague are both active.
 local function diseasesUp(sim)
     return sim.ff_up and sim.bp_up
 end
 
+---Returns time until next rune of the given type is ready.
 local function nextRuneReady(sim, runeType)
     if not sim.rune_recovery or not sim.rune_recovery[runeType] then
         return 999
@@ -74,13 +79,16 @@ end
 
 -- Preserve a Blood/Death rune for Glyph of Disease refresh windows.
 -- If we spend the last Blood/Death rune too early, diseases can drop and force IT+PS.
-local function shouldReserveDiseaseRefreshRune(sim)
+---Determines whether to reserve a blood/death rune for upcoming Pestilence refresh.
+-- pendingDeathCost: number of Death runes the candidate spell will consume (default 0).
+-- The check accounts for those runes being spent so we don't stave Pest of its rune.
+local function shouldReserveDiseaseRefreshRune(sim, pendingDeathCost)
     if not sim.has_glyph_disease or not diseasesUp(sim) then
         return false
     end
 
     local availableBD = (sim.blood or 0) + (sim.death or 0)
-    if availableBD > 1 then
+    if availableBD - (pendingDeathCost or 0) > 1 then
         return false
     end
 
@@ -89,9 +97,20 @@ local function shouldReserveDiseaseRefreshRune(sim)
         return false
     end
 
-    local timeUntilPestWindow = math.max(0, minDiseaseRemains - 3)
+    -- Wowsim uses a tighter 1.5s Pest window for sub-Blood and a looser 3.0s
+    -- window for sub-Unholy/Epidemic. We keep 1.5s here for both specs for now;
+    -- this can be loosened later if the reserve logic proves too strict.
+    local timeUntilSafeRefresh = math.max(0, minDiseaseRemains - 1.5)
     local nextBD = math.min(nextRuneReady(sim, "blood"), nextRuneReady(sim, "death"))
-    return nextBD > timeUntilPestWindow
+    return nextBD > timeUntilSafeRefresh
+end
+
+---Returns the number of Death runes Obliterate would consume (0, 1, or 2).
+-- Oblit costs 1 Frost + 1 Unholy; any shortfall is covered by Death runes.
+local function obliterateDeathRuneCost(sim)
+    local frostShortfall = math.max(0, 1 - (sim.frost or 0))
+    local unholyShortfall = math.max(0, 1 - (sim.unholy or 0))
+    return frostShortfall + unholyShortfall
 end
 
 -- ============================================================================
@@ -102,6 +121,7 @@ end
 
 -- Get per-rune cooldown remaining for all 6 slots, grouped by type
 -- Returns recovery timers AND the observed haste-adjusted rune CD duration
+---Reads rune cooldowns and returns per-type recovery timers and observed duration.
 local function GetRuneRecoveryTimes()
     local recovery = { blood = {}, frost = {}, unholy = {}, death = {} }
     local observedDuration = 10  -- fallback
@@ -132,6 +152,7 @@ local function GetRuneRecoveryTimes()
 end
 
 -- Tick rune recovery: as sim time advances, runes come off CD
+---Advances rune recovery timers and restores runes that have completed cooldown.
 local function tickRuneRecovery(sim, seconds)
     if not sim.rune_recovery then return end
     for _, runeType in ipairs({"blood", "frost", "unholy", "death"}) do
@@ -153,6 +174,7 @@ local function tickRuneRecovery(sim, seconds)
 end
 
 -- When spending a rune in the sim, queue its recovery using observed duration
+---Queues cooldown recovery for a spent rune of the given type.
 local function queueRuneRecovery(sim, runeType)
     if not sim.rune_recovery then return end
     if not sim.rune_recovery[runeType] then sim.rune_recovery[runeType] = {} end
@@ -161,6 +183,7 @@ local function queueRuneRecovery(sim, runeType)
 end
 
 -- Updated spendRunes that queues recovery
+---Consumes runes, queues their recovery timers, and grants RP.
 local function spendRunesTracked(sim, bCost, fCost, uCost, rpGain)
     -- Spend typed runes first, overflow to death
     local bSpend = math.min(bCost, sim.blood)
@@ -367,6 +390,7 @@ local bloodConfig = {
     end,
 }
 
+---Runs Blood DK simulation and returns recommendation list.
 local function GetBloodRecommendations(addon)
     return DH:RunSimulation(state, bloodConfig)
 end
@@ -426,6 +450,9 @@ local frostConfig = {
         sim.horn_of_winter_up = s.buff.horn_of_winter.up
         sim.strength_of_earth_totem_up = s.buff.strength_of_earth_totem.up
 
+        -- Epidemic talent: +3s disease duration per rank (max rank 3 = +6s)
+        sim.disease_duration = 15 + (s.talent.epidemic.rank or 0) * 3
+
         -- Glyph of Frost Strike (32 RP instead of 40)
         sim.fs_cost = (s.glyph.frost_strike and s.glyph.frost_strike.enabled) and 32 or 40
         sim.has_glyph_disease = s.glyph.disease and s.glyph.disease.enabled
@@ -451,6 +478,15 @@ local frostConfig = {
             return "pestilence"
         end
 
+        -- Blood Tap emergency: disease refresh fallback.
+        -- No Blood/Death rune for Pestilence when diseases are about to expire.
+        if sim.has_glyph_disease and sim.ff_up and sim.bp_up
+            and (sim.ff_remains < 3 or sim.bp_remains < 3)
+            and sim.blood == 0 and sim.death == 0
+            and sim:ready("blood_tap") then
+            return "blood_tap"
+        end
+
         -- Diseases: Icy Touch if Frost Fever down
         if (not sim.ff_up or sim.ff_remains < 3) and canAfford(sim, 0, 1, 0) then
             return "icy_touch"
@@ -461,38 +497,61 @@ local frostConfig = {
             return "plague_strike"
         end
 
-        -- Unbreakable Armor after presence and disease setup
+        -- Blood Tap opener: convert Blood → Death before UA so UA consumes
+        -- a Death rune instead of a Frost rune, keeping F+U paired.
+        -- NOTE: wowsim sub-Unholy (Epidemic) does Pest before BT+UA to start
+        -- Blood CD earlier; with 21s diseases the window is generous enough
+        -- that the current BT→UA→OB order still works safely for both specs.
+        if sim.has_unbreakable_armor and not sim.unbreakable_armor_up
+            and sim:ready("unbreakable_armor") and not DH:IsSnoozed("unbreakable_armor")
+            and sim.death == 0 and sim.blood > 0
+            and diseasesUp(sim) and sim:ready("blood_tap") then
+            return "blood_tap"
+        end
+
+        -- Unbreakable Armor after BT has created a Death rune (or if Death rune already exists)
         if sim.has_unbreakable_armor and not sim.unbreakable_armor_up
             and sim:ready("unbreakable_armor") and not DH:IsSnoozed("unbreakable_armor") then
             return "unbreakable_armor"
         end
 
-        -- Rime proc: free Howling Blast (also applies FF)
-        if sim.rime and sim.has_howling_blast then
+        -- Killing Machine: consume on Frost Strike for maximum crit value.
+        -- KM only buffs Icy Touch, Howling Blast, and Frost Strike — not Obliterate.
+        if sim.killing_machine and sim.has_frost_strike and sim.rp >= sim.fs_cost then
+            return "frost_strike"
+        end
+
+        -- Rime proc: free Howling Blast (also applies FF).
+        -- Skip when KM is active to preserve the proc for Frost Strike.
+        if sim.rime and sim.has_howling_blast and not sim.killing_machine then
             return "howling_blast"
         end
 
-        -- Killing Machine proc: use on Obliterate for big crit
-        if sim.killing_machine and diseasesUp(sim) and canAfford(sim, 0, 1, 1) then
+        -- Obliterate (main damage, Frost+Unholy) - only with diseases.
+        -- OB does not consume KM, so it's safe to cast while KM is up.
+        if diseasesUp(sim) and canAfford(sim, 0, 1, 1)
+            and not shouldReserveDiseaseRefreshRune(sim, obliterateDeathRuneCost(sim)) then
             return "obliterate"
         end
 
-        -- Obliterate (main damage, Frost+Unholy) - only with diseases
-        if diseasesUp(sim) and canAfford(sim, 0, 1, 1) then
-            return "obliterate"
-        end
+            -- Empower Rune Weapon: fire before Frost Strike/Blood Strike when F/U/Blood are all gone
+            -- and we cannot reach an Obliterate (e.g. post-Pestilence opener: F:0,U:0,B:0,D:1 left).
+            -- Note: live updates can still show ERW briefly in slot 2/3 if an earlier projection
+            -- is consumed by a higher-priority GCD spender before ERW reaches the top slot.
+            if sim.frost == 0 and sim.unholy == 0 and sim.blood == 0
+                and not canAfford(sim, 0, 1, 1)
+                and sim:ready("empower_rune_weapon") and not DH:IsSnoozed("empower_rune_weapon") then
+                return "empower_rune_weapon"
+            end
 
         -- Frost Strike (RP dump)
         if sim.has_frost_strike and sim.rp >= sim.fs_cost then
             return "frost_strike"
         end
 
-        -- Blood Tap: create a Death rune when exactly one Obliterate rune is missing.
-        -- This supports opener sequencing like IT -> PS -> UA -> BT -> OB.
-        if sim.blood > 0 and sim.death == 0
-            and ((sim.frost == 0 and sim.unholy > 0) or (sim.unholy == 0 and sim.frost > 0) or (sim.frost == 0 and sim.unholy == 0))
-            and diseasesUp(sim) and sim:ready("blood_tap") then
-            return "blood_tap"
+        -- Rime fallback: if we couldn't OB or FS above, use the Rime proc now
+        if sim.rime and sim.has_howling_blast then
+            return "howling_blast"
         end
 
         -- Opener Pestilence sync: F+U spent after first OB, Blood rune still available,
@@ -505,22 +564,17 @@ local frostConfig = {
             return "pestilence"
         end
 
-        -- Empower Rune Weapon: fire before Blood Strike when F/U/Blood are all gone and we
-        -- cannot reach an Obliterate (e.g. post-Pestilence opener: F:0,U:0,B:0,D:1 left)
-        if sim.frost == 0 and sim.unholy == 0 and sim.blood == 0
-            and not canAfford(sim, 0, 1, 1)
-            and sim:ready("empower_rune_weapon") and not DH:IsSnoozed("empower_rune_weapon") then
-            return "empower_rune_weapon"
-        end
-
         -- Blood Strike (Blood rune spender, converts to Death runes)
         -- Keep one Blood/Death rune banked if Glyph of Disease refresh is approaching.
         if canAfford(sim, 1, 0, 0) and not shouldReserveDiseaseRefreshRune(sim) then
             return "blood_strike"
         end
 
-        -- Horn of Winter (free GCD, RP gen) only if off cooldown
-        if sim:ready("horn_of_winter") then
+        -- Horn of Winter (filler: only when no rune is about to recover)
+        local minRune = math.min(
+            nextRuneReady(sim, "blood"), nextRuneReady(sim, "frost"),
+            nextRuneReady(sim, "unholy"), nextRuneReady(sim, "death"))
+        if sim:ready("horn_of_winter") and minRune > 0.5 then
             return "horn_of_winter"
         end
 
@@ -532,11 +586,11 @@ local frostConfig = {
         elseif key == "icy_touch" then
             spendRunesTracked(sim, 0, 1, 0, 10)
             sim.ff_up = true
-            sim.ff_remains = 15
+            sim.ff_remains = sim.disease_duration
         elseif key == "plague_strike" then
             spendRunesTracked(sim, 0, 0, 1, 10)
             sim.bp_up = true
-            sim.bp_remains = 15
+            sim.bp_remains = sim.disease_duration
         elseif key == "obliterate" then
             spendRunesTracked(sim, 0, 1, 1, 15)
             sim.killing_machine = false
@@ -546,7 +600,7 @@ local frostConfig = {
             end
             sim.rime = false
             sim.ff_up = true
-            sim.ff_remains = 15
+            sim.ff_remains = sim.disease_duration
         elseif key == "unbreakable_armor" then
             spendRunesTracked(sim, 0, 1, 0, 0)
             sim.rp = math.min(sim.rp_max, sim.rp + 10)
@@ -559,6 +613,9 @@ local frostConfig = {
             if sim.blood > 0 then
                 sim.blood = sim.blood - 1
                 sim.death = sim.death + 1
+            else
+                -- Activate a depleted Blood rune as Death
+                sim.death = sim.death + 1
             end
         elseif key == "empower_rune_weapon" then
             sim.blood = 2
@@ -569,8 +626,8 @@ local frostConfig = {
         elseif key == "pestilence" then
             spendRunesTracked(sim, 1, 0, 0, 10)
             if sim.has_glyph_disease then
-                sim.ff_remains = 15
-                sim.bp_remains = 15
+                sim.ff_remains = sim.disease_duration
+                sim.bp_remains = sim.disease_duration
             end
         elseif key == "horn_of_winter" then
             sim.rp = math.min(sim.rp_max, sim.rp + 10)
@@ -579,6 +636,12 @@ local frostConfig = {
     end,
     tickTime = function(sim, seconds)
         tickRuneRecovery(sim, seconds)
+    end,
+    getAdvanceTime = function(sim, action)
+        if action == "blood_tap" then
+            return 0
+        end
+        return sim.gcd
     end,
     getWaitTime = function(sim)
         local nearest = 999
@@ -594,6 +657,7 @@ local frostConfig = {
     end,
 }
 
+---Runs Frost DK simulation and returns recommendation list.
 local function GetFrostRecommendations(addon)
     return DH:RunSimulation(state, frostConfig)
 end
@@ -764,6 +828,7 @@ local unholyConfig = {
     end,
 }
 
+---Runs Unholy DK simulation and returns recommendation list.
 local function GetUnholyRecommendations(addon)
     return DH:RunSimulation(state, unholyConfig)
 end

--- a/Classes/DeathKnight/Core.lua
+++ b/Classes/DeathKnight/Core.lua
@@ -433,7 +433,8 @@ local frostConfig = {
     end,
     getPriority = function(sim, recs)
         -- Keep AP/STR raid buff up: Horn if neither Horn nor Strength of Earth is active
-        if not sim.horn_of_winter_up and not sim.strength_of_earth_totem_up then
+        if not sim.horn_of_winter_up and not sim.strength_of_earth_totem_up
+            and sim:ready("horn_of_winter") then
             return "horn_of_winter"
         end
 
@@ -547,6 +548,8 @@ local frostConfig = {
             sim.ff_up = true
             sim.ff_remains = 15
         elseif key == "unbreakable_armor" then
+            spendRunesTracked(sim, 0, 1, 0, 0)
+            sim.rp = math.min(sim.rp_max, sim.rp + 10)
             sim.unbreakable_armor_up = true
         elseif key == "blood_strike" then
             spendRunesTracked(sim, 1, 0, 0, 10)

--- a/Classes/DeathKnight/Core.lua
+++ b/Classes/DeathKnight/Core.lua
@@ -88,7 +88,7 @@ local function shouldReserveDiseaseRefreshRune(sim, pendingDeathCost)
     end
 
     local availableBD = (sim.blood or 0) + (sim.death or 0)
-    if availableBD - (pendingDeathCost or 0) > 1 then
+    if availableBD - (pendingDeathCost or 0) >= 1 then
         return false
     end
 
@@ -360,6 +360,7 @@ local bloodConfig = {
             sim.blood = 2
             sim.frost = 2
             sim.unholy = 2
+            sim.death = 0
             sim.rp = math.min(sim.rp_max, sim.rp + 25)
             sim.rune_recovery = { blood = {}, frost = {}, unholy = {}, death = {} }
         elseif key == "pestilence" then
@@ -566,7 +567,7 @@ local frostConfig = {
 
         -- Blood Strike (Blood rune spender, converts to Death runes)
         -- Keep one Blood/Death rune banked if Glyph of Disease refresh is approaching.
-        if canAfford(sim, 1, 0, 0) and not shouldReserveDiseaseRefreshRune(sim) then
+        if canAfford(sim, 1, 0, 0) and not shouldReserveDiseaseRefreshRune(sim, 1) then
             return "blood_strike"
         end
 
@@ -602,7 +603,12 @@ local frostConfig = {
             sim.ff_up = true
             sim.ff_remains = sim.disease_duration
         elseif key == "unbreakable_armor" then
-            spendRunesTracked(sim, 0, 1, 0, 0)
+            if sim.death > 0 then
+                sim.death = sim.death - 1
+                queueRuneRecovery(sim, "death")
+            else
+                spendRunesTracked(sim, 0, 1, 0, 0)
+            end
             sim.rp = math.min(sim.rp_max, sim.rp + 10)
             sim.unbreakable_armor_up = true
         elseif key == "blood_strike" then
@@ -610,17 +616,23 @@ local frostConfig = {
         elseif key == "frost_strike" then
             spendRP(sim, sim.fs_cost)
         elseif key == "blood_tap" then
-            if sim.blood > 0 then
+            local hasDepletedBlood = sim.rune_recovery and sim.rune_recovery.blood
+                and #sim.rune_recovery.blood > 0
+            if hasDepletedBlood then
+                -- Activate depleted Blood rune as Death (preserves ready Blood for Pestilence)
+                table.remove(sim.rune_recovery.blood, 1)
+                sim.death = sim.death + 1
+            elseif sim.blood > 0 then
                 sim.blood = sim.blood - 1
                 sim.death = sim.death + 1
             else
-                -- Activate a depleted Blood rune as Death
                 sim.death = sim.death + 1
             end
         elseif key == "empower_rune_weapon" then
             sim.blood = 2
             sim.frost = 2
             sim.unholy = 2
+            sim.death = 0
             sim.rp = math.min(sim.rp_max, sim.rp + 25)
             sim.rune_recovery = { blood = {}, frost = {}, unholy = {}, death = {} }
         elseif key == "pestilence" then
@@ -799,6 +811,7 @@ local unholyConfig = {
             sim.blood = 2
             sim.frost = 2
             sim.unholy = 2
+            sim.death = 0
             sim.rp = math.min(sim.rp_max, sim.rp + 25)
             sim.rune_recovery = { blood = {}, frost = {}, unholy = {}, death = {} }
         elseif key == "pestilence" then

--- a/Classes/DeathKnight/Core.lua
+++ b/Classes/DeathKnight/Core.lua
@@ -535,15 +535,15 @@ local frostConfig = {
             return "obliterate"
         end
 
-            -- Empower Rune Weapon: fire before Frost Strike/Blood Strike when F/U/Blood are all gone
-            -- and we cannot reach an Obliterate (e.g. post-Pestilence opener: F:0,U:0,B:0,D:1 left).
-            -- Note: live updates can still show ERW briefly in slot 2/3 if an earlier projection
-            -- is consumed by a higher-priority GCD spender before ERW reaches the top slot.
-            if sim.frost == 0 and sim.unholy == 0 and sim.blood == 0
-                and not canAfford(sim, 0, 1, 1)
-                and sim:ready("empower_rune_weapon") and not DH:IsSnoozed("empower_rune_weapon") then
-                return "empower_rune_weapon"
-            end
+        -- Empower Rune Weapon: fire before Frost Strike/Blood Strike when F/U/Blood are all gone
+        -- and we cannot reach an Obliterate (e.g. post-Pestilence opener: F:0,U:0,B:0,D:1 left).
+        -- Note: live updates can still show ERW briefly in slot 2/3 if an earlier projection
+        -- is consumed by a higher-priority GCD spender before ERW reaches the top slot.
+        if sim.frost == 0 and sim.unholy == 0 and sim.blood == 0
+            and not canAfford(sim, 0, 1, 1)
+            and sim:ready("empower_rune_weapon") and not DH:IsSnoozed("empower_rune_weapon") then
+            return "empower_rune_weapon"
+        end
 
         -- Frost Strike (RP dump)
         if sim.has_frost_strike and sim.rp >= sim.fs_cost then
@@ -594,7 +594,6 @@ local frostConfig = {
             sim.bp_remains = sim.disease_duration
         elseif key == "obliterate" then
             spendRunesTracked(sim, 0, 1, 1, 15)
-            sim.killing_machine = false
         elseif key == "howling_blast" then
             if not sim.rime then
                 spendRunesTracked(sim, 0, 1, 1, 15)
@@ -624,8 +623,6 @@ local frostConfig = {
                 sim.death = sim.death + 1
             elseif sim.blood > 0 then
                 sim.blood = sim.blood - 1
-                sim.death = sim.death + 1
-            else
                 sim.death = sim.death + 1
             end
         elseif key == "empower_rune_weapon" then

--- a/Classes/DeathKnight/DeathKnight.lua
+++ b/Classes/DeathKnight/DeathKnight.lua
@@ -452,9 +452,8 @@ DH:RegisterGlyphs({
     [58669] = "death_strike",
     [58671] = "heart_strike",
     [58680] = "rune_strike",
-    [63334] = "dancing_rune_weapon",
-    [58673] = "disease",
-    [63334] = "disease",
+    [63330] = "dancing_rune_weapon",
+    [64267] = "disease",
     [58676] = "horn_of_winter",
 })
 
@@ -464,6 +463,14 @@ DH:RegisterBuffMap({
     [48266] = "frost_presence",
     [48265] = "unholy_presence",
     [57623] = "horn_of_winter",
+    -- Strength of Earth (all ranks) so HoW suppression works regardless of aura rank
+    [8076] = "strength_of_earth_totem",
+    [8160] = "strength_of_earth_totem",
+    [8161] = "strength_of_earth_totem",
+    [10442] = "strength_of_earth_totem",
+    [25361] = "strength_of_earth_totem",
+    [25528] = "strength_of_earth_totem",
+    [57622] = "strength_of_earth_totem",
     [58643] = "strength_of_earth_totem",
     [51124] = "killing_machine",
     [59052] = "freezing_fog",

--- a/Classes/DeathKnight/DeathKnight.lua
+++ b/Classes/DeathKnight/DeathKnight.lua
@@ -242,6 +242,7 @@ for key, ability in pairs(class.abilities) do
     end
 end
 
+---Returns icon texture path for an ability key, with fallback question mark icon.
 function ns.GetAbilityTexture(key)
     local ability = class.abilities[key]
     if ability then
@@ -261,6 +262,7 @@ end
 DH:RegisterGCDSpell(SPELLS.ICY_TOUCH)
 
 -- Presence form handlers (GetShapeshiftForm: 1=Blood, 2=Frost, 3=Unholy)
+---Clears presence form auras before applying the currently active presence.
 local function ResetPresences(state)
     state.buff.blood_presence.expires = 0
     state.buff.blood_presence._isForm = true
@@ -453,7 +455,7 @@ DH:RegisterGlyphs({
     [58671] = "heart_strike",
     [58680] = "rune_strike",
     [63330] = "dancing_rune_weapon",
-    [64267] = "disease",
+    [63334] = "disease",
     [58676] = "horn_of_winter",
 })
 
@@ -548,6 +550,7 @@ DH:RegisterSnoozeable("empower_rune_weapon", 60)
 -- Rune slots: 1-2 Blood, 3-4 Unholy, 5-6 Frost (or Death runes)
 -- ============================================================================
 
+---Returns counts of ready blood, frost, unholy, and death runes.
 function ns.GetRuneCounts()
     local blood, frost, unholy, death = 0, 0, 0, 0
     for i = 1, 6 do

--- a/Classes/DeathKnight/DeathKnight.lua
+++ b/Classes/DeathKnight/DeathKnight.lua
@@ -26,6 +26,7 @@ local SPELLS = {
     OBLITERATE = 51425,
     FROST_STRIKE = 55268,
     HOWLING_BLAST = 51411,
+    UNBREAKABLE_ARMOR = 51271,
 
     -- Unholy
     SCOURGE_STRIKE = 55271,
@@ -101,6 +102,11 @@ class.abilities = {
         id = SPELLS.HOWLING_BLAST,
         name = "Howling Blast",
         texture = 237533,
+    },
+    unbreakable_armor = {
+        id = SPELLS.UNBREAKABLE_ARMOR,
+        name = "Unbreakable Armor",
+        texture = 237510,
     },
 
     -- Unholy
@@ -289,8 +295,10 @@ DH:RegisterMeleeAbilities({
 DH:RegisterBuffs({
     "blood_presence", "frost_presence", "unholy_presence",
     "horn_of_winter",
+    "strength_of_earth_totem",
     "killing_machine",
     "freezing_fog",     -- Rime proc (free Howling Blast)
+    "unbreakable_armor",
     "sudden_doom",      -- Free Death Coil proc
     "bone_shield",
     "vampiric_blood",
@@ -316,6 +324,7 @@ DH:RegisterCooldowns({
     obliterate = 51425,
     frost_strike = 55268,
     howling_blast = 51411,
+    unbreakable_armor = 51271,
     scourge_strike = 55271,
     death_coil = 49895,
     heart_strike = 55262,
@@ -436,6 +445,7 @@ DH:RegisterGlyphs({
     [58631] = "icy_touch",
     [58657] = "obliterate",
     [58625] = "frost_strike",
+    [58647] = "frost_strike",
     [63331] = "howling_blast",
     [58642] = "scourge_strike",
     [58677] = "death_coil",
@@ -454,8 +464,10 @@ DH:RegisterBuffMap({
     [48266] = "frost_presence",
     [48265] = "unholy_presence",
     [57623] = "horn_of_winter",
+    [58643] = "strength_of_earth_totem",
     [51124] = "killing_machine",
     [59052] = "freezing_fog",
+    [51271] = "unbreakable_armor",
     [81340] = "sudden_doom",
     [49222] = "bone_shield",
     [55233] = "vampiric_blood",

--- a/Classes/DeathKnight/DeathKnight.lua
+++ b/Classes/DeathKnight/DeathKnight.lua
@@ -502,6 +502,11 @@ DH:RegisterDebuffNamePatterns({
     { "crypt fever", "crypt_fever" },
 })
 
+-- Name-based fallback for buffs whose spell IDs vary by rank/talent
+DH:RegisterBuffNamePatterns({
+    { "strength of earth", "strength_of_earth_totem" },
+})
+
 DH:RegisterExternalDebuffMap({})
 DH:RegisterExternalDebuffNamePatterns({})
 

--- a/PriorityHelper.lua
+++ b/PriorityHelper.lua
@@ -480,6 +480,7 @@ ns.registered = {
     externalDebuffMap = {},  -- { [spellId] = debuffKey, ... }
     debuffNamePatterns = {},  -- { { pattern, key }, ... } for name-based fallback
     externalDebuffNamePatterns = {},  -- same for external debuffs
+    buffNamePatterns = {},  -- { { pattern, key }, ... } for name-based buff fallback
     combatLogHandlers = {},  -- Functions called on COMBAT_LOG_EVENT_UNFILTERED
     formHandlers = {},    -- { formId = { update = fn, spec = fn }, ... }
     specDetector = nil,   -- Function that returns current spec string
@@ -549,6 +550,13 @@ end
 function DH:RegisterDebuffNamePatterns(patterns)
     for _, data in ipairs(patterns) do
         table.insert(ns.registered.debuffNamePatterns, data)
+    end
+end
+
+-- Register buff name patterns for fallback matching
+function DH:RegisterBuffNamePatterns(patterns)
+    for _, data in ipairs(patterns) do
+        table.insert(ns.registered.buffNamePatterns, data)
     end
 end
 

--- a/State.lua
+++ b/State.lua
@@ -434,6 +434,18 @@ function state:UpdateBuffs()
         if not name then break end
 
         local key = ns.registered.buffMap[spellId]
+
+        -- Fallback to name patterns
+        if not key and name then
+            local lowerName = name:lower()
+            for _, pattern in ipairs(ns.registered.buffNamePatterns) do
+                if lowerName:find(pattern[1]) then
+                    key = pattern[2]
+                    break
+                end
+            end
+        end
+
         if key and self.buff[key] then
             -- Permanent buffs (Righteous Fury, auras, etc.) have expirationTime = 0
             if not expirationTime or expirationTime == 0 then


### PR DESCRIPTION
- Switch presence requirement from Unholy to Blood
- Add Unbreakable Armor and Blood Tap cooldown tracking
- Uses Pestilence to keep diseases up when glyphed.
- Implemented a tracker to not spend blood/death runes when using Glyph of Disease to allow pestilence to keep diseases up.
- Move Frost Strike above Blood Strike in priority order
- Add Horn of Winter AP/STR buff check as top-priority gate
- Track Horn of Winter cooldown to prevent recommending while on CD
- Add Strength of Earth Totem buff detection as HoW substitute
- Rework Blood Tap to fire for opener Obliterate windows
- Add opener Pestilence sync (Glyph of Disease + ERW ready)
- Add ERW recommendation when F/U/Blood are spent post-Pestilence
- Reserve last Blood/Death rune when disease refresh window < 8s
- Register Unbreakable Armor ability, buff, cooldown, and buff map
- Add Frost Strike glyph alternate spell ID (58647)

- Issue: ERW appears in future priorities but doesn't make it to the first position. Needs testing by other players first - FIXED - Raid tested and functional.
- Issue: Occasionally runes are allowed to be spent, causing diseases to fall off - FIXED - Raid tested and functional.
- edit: Tested in a raid environment - Strength of Earth Totem being present caused HoW to be permanently in the 1st recommended slot. FIXED - Raid tested and functional.

## Summary
Reworked Frost DPS priorities - 

## Type
- [ ] New class/spec
- [X] Rotation fix
- [ ] Framework change
- [ ] Bug fix
- [ ] Other

## Changes
<!-- What files were changed and why -->

## Rotation Source
<!-- If rotation changes: link to wowsim APL, wowhead guide, or other reference -->

## Testing
- [X] Tested in-game on target dummy
- [X] Tested with `/ph status` and `/ph live`
- [X] Verified priority order matches source guide
- [X] No lua errors on login or `/reload`
- [ ] Existing classes still work (if framework change)

## Checklist
- [X] Class files are in `Classes/<ClassName>/`
- [ ] TOC updated (new files BEFORE Config.lua)
- [ ] DESIGN.md updated (if new patterns introduced)
- [ ] README.md updated (if new class/spec added)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Unbreakable Armor support and enhanced rune/runic power helpers with future-availability estimates.

* **Improvements**
  * Smarter rune reservation to preserve disease-refresh windows and avoid consuming last Blood/Death runes.
  * Frost rotation refinements: earlier Horn of Winter usage, enforced Blood presence ordering, Killing Machine → Frost Strike priority, Pestilence-sync opener option, and Blood Tap emergency behavior.

* **Buff Tracking**
  * Expanded tracking for Horn of Winter, Strength of Earth Totem, Unbreakable Armor and related auras.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->